### PR TITLE
Support for searching when the year is added to the end of a sentence.

### DIFF
--- a/server/api/fixtures/test_data.json
+++ b/server/api/fixtures/test_data.json
@@ -388,5 +388,31 @@
         "f": 8,
         "gpa": 3.08
     }
+},
+{
+    "model": "api.gradeinfo",
+    "pk":16,
+    "fields": {
+        "subject": "年度テスト",
+        "lecture": " ",
+        "group": "現代test",
+        "teacher": "test",
+        "year": "9999",
+        "semester": "2学期",
+        "faculty": "総合教育部",
+        "numOfStudents": 198,
+        "ap": 16,
+        "a": 24,
+        "am": 30,
+        "bp": 39,
+        "b": 25,
+        "bm": 24,
+        "cp": 17,
+        "c": 12,
+        "d": 3,
+        "dm": 0,
+        "f": 8,
+        "gpa": 3.08
+    }
 }
 ]

--- a/server/api/tests/test_filter.py
+++ b/server/api/tests/test_filter.py
@@ -93,6 +93,25 @@ class FilterTest(APITestCase):
         actual = self.get_pk_from_list(response.json()['results'])
         self.assertEqual(actual, [14, 13, 15])
 
+    def test_year(self):
+        response = self.client.get('/api/gradeinfo/?search=9999')
+        res = response.json()['results']
+        self.assertEqual(len(res), 1)
+        actual = res[0]['id']
+        self.assertEqual(actual, 16)
+
+        response = self.client.get('/api/gradeinfo/?search=9999年')
+        res = response.json()['results']
+        self.assertEqual(len(res), 1)
+        actual = res[0]['id']
+        self.assertEqual(actual, 16)
+
+        response = self.client.get('/api/gradeinfo/?search=9999年度')
+        res = response.json()['results']
+        self.assertEqual(len(res), 1)
+        actual = res[0]['id']
+        self.assertEqual(actual, 16)
+
     @staticmethod
     def get_pk_from_list(arr):
         return list(map(lambda x: x['id'], arr))


### PR DESCRIPTION
2020年度, 2020年などと検索したときに成績がヒットするように修正